### PR TITLE
feat: create output directory if it does not exist

### DIFF
--- a/lib/src/arb_creator.dart
+++ b/lib/src/arb_creator.dart
@@ -10,6 +10,12 @@ class ArbCreator {
 
   Future<void> writeToFile(String directory, List<String> languageCodes,
       List<Translation> translations) async {
+    // Create output directory if it doesn't exist
+    final outputDir = Directory(directory);
+    if (!outputDir.existsSync()) {
+      outputDir.createSync(recursive: true);
+    }
+
     for (final languageCode in languageCodes) {
       final file = File(join(directory, 'app_$languageCode.arb'));
       final data = <String, dynamic>{};

--- a/test/cli_test.dart
+++ b/test/cli_test.dart
@@ -118,6 +118,33 @@ void main() {
     expect(secondRun, firstRun);
   });
 
+  test('creates output directory if it does not exist', () async {
+    final nonExistentDir =
+        Directory(p.join(projectRoot, 'tmp_output_nonexistent'));
+    if (nonExistentDir.existsSync()) {
+      nonExistentDir.deleteSync(recursive: true);
+    }
+
+    final excelUrl = serverUri.resolve('test/fixtures/basic.xlsx').toString();
+    final result = await runCli(
+        ['-u', excelUrl, '-s', 'Localization', '-o', nonExistentDir.path]);
+
+    expect(result.exitCode, 0,
+        reason:
+            'CLI should succeed when output directory does not exist: ${result.stderr}');
+    expect(nonExistentDir.existsSync(), isTrue,
+        reason: 'Output directory should be created');
+
+    final outputFiles = await readDirFiles(nonExistentDir);
+    expect(outputFiles.keys, isNotEmpty,
+        reason: 'ARB files should be generated in created directory');
+
+    // Cleanup
+    if (nonExistentDir.existsSync()) {
+      nonExistentDir.deleteSync(recursive: true);
+    }
+  });
+
   test('--help output matches golden snapshot', () async {
     final result = await runCli(['--help']);
     expect([0, 2].contains(result.exitCode), isTrue,


### PR DESCRIPTION
- add directory creation in ArbCreator.writeToFile
- add test case for missing output directory scenario
- fix PathNotFoundException when output directory is missing